### PR TITLE
Allow partitions other than user for u-boot env

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
@@ -1,24 +1,23 @@
-From c07ad477cd5715079a3bd086293e0adf91f15b88 Mon Sep 17 00:00:00 2001
-From: Drew Moseley <drew.moseley@northern.tech>
-Date: Sun, 28 Jan 2018 17:44:32 -0500
-Subject: [PATCH] Generic boot code for Mender.
+From b2b8da3c6b4ff8afd8628e28c6b6bdd37a7be490 Mon Sep 17 00:00:00 2001
+From: Dan Walkes <danwalkes@trellis-logic.com>
+Date: Fri, 2 Aug 2019 07:05:03 -0600
+Subject: [PATCH] Generic boot code for Mender
 
-Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
-Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
-Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+Minor changes from previous patch by Drew Moseley to allow specifying
+CONFIG_SYS_MMC_ENV_PART != 0
 ---
- include/config_mender.h |  98 +++++++++++++++++++++++++++++++
- include/env_mender.h    | 152 ++++++++++++++++++++++++++++++++++++++++++++++++
- 2 files changed, 250 insertions(+)
+ include/config_mender.h |  94 +++++++++++++++++++++++++
+ include/env_mender.h    | 152 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 246 insertions(+)
  create mode 100644 include/config_mender.h
  create mode 100644 include/env_mender.h
 
 diff --git a/include/config_mender.h b/include/config_mender.h
 new file mode 100644
-index 0000000..3836a6d
+index 0000000000..69a526805d
 --- /dev/null
 +++ b/include/config_mender.h
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,94 @@
 +/*
 +  Copyright 2017 Northern.tech AS
 +
@@ -96,11 +95,7 @@ index 0000000..3836a6d
 +# else
 +#  define CONFIG_SYS_MMC_ENV_DEV   MENDER_UBOOT_STORAGE_DEVICE
 +# endif
-+# ifdef CONFIG_SYS_MMC_ENV_PART
-+#  if CONFIG_SYS_MMC_ENV_PART != 0
-+#   error CONFIG_SYS_MMC_ENV_PART need to be set to 0. Make sure that: 1) All the instructions at docs.mender.io/devices/integrating-with-u-boot have been followed. 2) All required layers are included in bblayers.conf, including any board specific layers such as meta-mender-<board>
-+#  endif
-+# else
++# ifndef CONFIG_SYS_MMC_ENV_PART
 +   /* Use MMC partition zero to select whole user area of memory card. */
 +#  define CONFIG_SYS_MMC_ENV_PART  0
 +# endif
@@ -119,7 +114,7 @@ index 0000000..3836a6d
 +#endif /* HEADER_CONFIG_MENDER_H */
 diff --git a/include/env_mender.h b/include/env_mender.h
 new file mode 100644
-index 0000000..a1996ab
+index 0000000000..6fde590e5c
 --- /dev/null
 +++ b/include/env_mender.h
 @@ -0,0 +1,152 @@
@@ -275,6 +270,3 @@ index 0000000..a1996ab
 +#endif /* !MENDER_AUTO_PROBING */
 +
 +#endif /* HEADER_ENV_MENDER_H */
--- 
-2.7.4
-

--- a/meta-mender-core/recipes-bsp/u-boot/patches/0007-Support-wrapper-scripts-for-fw_setenv.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0007-Support-wrapper-scripts-for-fw_setenv.patch
@@ -1,0 +1,44 @@
+From 1c08a73ee241ccce0f419fa1243c9b3fd09a743d Mon Sep 17 00:00:00 2001
+From: Dan Walkes <danwalkes@trellis-logic.com>
+Date: Sat, 3 Aug 2019 17:07:01 -0600
+Subject: [PATCH] Support wrapper scripts for fw_setenv
+
+When u-boot enviroment is stored to a read-only boot partition, it
+may be useful for a wrapper script to handle disabling read only status
+around fw_setenv invocation. See the example script below:
+
+```
+echo 0 > /sys/block/mmcblk0boot1/force_ro
+set -e
+/sbin/fw_setenv_nounlock "$@"
+set +e
+echo 1 > /sys/block/mmcblk0boot1/force_ro
+```
+
+To allow this, use any invocation which starts with fw_setenv to invoke
+the set environment function instead of requiring a name which exactly
+matches fw_setenv.
+
+Signed-off-by: Dan Walkes <danwalkes@trellis-logic.com>
+---
+ tools/env/fw_env_main.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/env/fw_env_main.c b/tools/env/fw_env_main.c
+index 443de36e43..8092636bb1 100644
+--- a/tools/env/fw_env_main.c
++++ b/tools/env/fw_env_main.c
+@@ -222,11 +222,11 @@ int main(int argc, char *argv[])
+ 
+ 	if (strcmp(_cmdname, CMD_PRINTENV) == 0) {
+ 		do_printenv = 1;
+-	} else if (strcmp(_cmdname, CMD_SETENV) == 0) {
++	} else if (strstr(_cmdname, CMD_SETENV) == _cmdname) {
+ 		do_printenv = 0;
+ 	} else {
+ 		fprintf(stderr,
+-			"Identity crisis - may be called as `%s' or as `%s' but not as `%s'\n",
++			"Identity crisis - may be called as `%s' or as `%sXXXX' but not as `%s'\n",
+ 			CMD_PRINTENV, CMD_SETENV, _cmdname);
+ 		exit(EXIT_FAILURE);
+ 	}

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc
@@ -1,6 +1,7 @@
 require u-boot-mender-common.inc
 
 FILES_${PN}_append_mender-uboot = " /data/u-boot/fw_env.config"
+RDEPENDS_${PN} += "bash"
 
 do_compile_append_mender-uboot() {
     alignment_bytes=${MENDER_PARTITION_ALIGNMENT}
@@ -23,12 +24,13 @@ do_install_append_mender-uboot() {
     install -d ${D}/data/u-boot
     install -m 0644 ${WORKDIR}/fw_env.config ${D}/data/u-boot/fw_env.config
     if [ ${MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART} != 0 ]; then
-        install -d ${D}${sysconfdir}/profile.d/
-        echo 'fw_setenv() {' > ${WORKDIR}/fw_unlock_mmc.sh
-        echo "      echo 0 > /sys/block/${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE}/force_ro" >> ${WORKDIR}/fw_unlock_mmc.sh
-        echo '      /sbin/fw_setenv "$@"' >> ${WORKDIR}/fw_unlock_mmc.sh
-        echo "      echo 1 > /sys/block/${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE}/force_ro" >> ${WORKDIR}/fw_unlock_mmc.sh
-        echo '}' >> ${WORKDIR}/fw_unlock_mmc.sh
-        install -m 0644 ${WORKDIR}/fw_unlock_mmc.sh ${D}${sysconfdir}/profile.d/fw_unlock_mmc.sh
+        echo '#!/bin/bash' > ${WORKDIR}/fw_unlock_mmc.sh
+        echo "echo 0 > /sys/block/${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE}/force_ro" >> ${WORKDIR}/fw_unlock_mmc.sh
+        echo 'set -e' >> ${WORKDIR}/fw_unlock_mmc.sh
+        echo '/sbin/fw_setenv_nounlock "$@"' >> ${WORKDIR}/fw_unlock_mmc.sh
+        echo 'set +e' >> ${WORKDIR}/fw_unlock_mmc.sh
+        echo "echo 1 > /sys/block/${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE}/force_ro" >> ${WORKDIR}/fw_unlock_mmc.sh
+        install -m 755 ${D}${base_sbindir}/fw_setenv ${D}${base_sbindir}/fw_setenv_nounlock
+        install -m 755 ${WORKDIR}/fw_unlock_mmc.sh ${D}${base_sbindir}/fw_setenv
     fi
 }

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc
@@ -22,4 +22,13 @@ do_install_append_mender-uboot() {
 
     install -d ${D}/data/u-boot
     install -m 0644 ${WORKDIR}/fw_env.config ${D}/data/u-boot/fw_env.config
+    if [ ${MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART} != 0 ]; then
+        install -d ${D}${sysconfdir}/profile.d/
+        echo 'fw_setenv() {' > ${WORKDIR}/fw_unlock_mmc.sh
+        echo "      echo 0 > /sys/block/${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE}/force_ro" >> ${WORKDIR}/fw_unlock_mmc.sh
+        echo '      /sbin/fw_setenv "$@"' >> ${WORKDIR}/fw_unlock_mmc.sh
+        echo "      echo 1 > /sys/block/${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE}/force_ro" >> ${WORKDIR}/fw_unlock_mmc.sh
+        echo '}' >> ${WORKDIR}/fw_unlock_mmc.sh
+        install -m 0644 ${WORKDIR}/fw_unlock_mmc.sh ${D}${sysconfdir}/profile.d/fw_unlock_mmc.sh
+    fi
 }

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -138,6 +138,7 @@ do_provide_mender_defines() {
 #define MENDER_ROOTFS_PART_B_NUMBER_HEX $MENDER_ROOTFS_PART_B_NUMBER_HEX
 #define MENDER_UBOOT_STORAGE_INTERFACE "$MENDER_UBOOT_STORAGE_INTERFACE"
 #define MENDER_UBOOT_STORAGE_DEVICE $MENDER_UBOOT_STORAGE_DEVICE
+#define MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART ${MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART}
 
 /* BB variables. */
 #define MENDER_STORAGE_DEVICE "${MENDER_STORAGE_DEVICE}"
@@ -371,6 +372,22 @@ python() {
 # Helpers and internal variables.
 ################################################################################
 
+def mender_get_uboot_env_mmc_linux_device(d):
+    # Convert u-boot partition numbers to linux device references
+    # See [CONFIG_SYS_MMC_ENV_PART](https://github.com/u-boot/u-boot/blob/u-boot-2016.09.y/README#L4390) and
+    # [linux kernel mmc-dev-parts documentation](https://www.kernel.org/doc/Documentation/mmc/mmc-dev-parts.txt)
+    storage_device=d.getVar("MENDER_STORAGE_DEVICE",True)
+    env_part=d.getVar("MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART",True)
+    env_part_append=""
+    if env_part == "1":
+        env_part_append="boot0"
+    elif env_part == "2":
+        env_part_append="boot1"
+    return storage_device.replace("/dev/","",1) + env_part_append
+
+# The device portion of the uboot environment path (IE mmcblk0boot1 or mmcblk0)
+MENDER_UBOOT_MMC_ENV_LINUX_DEVICE ?= "${@mender_get_uboot_env_mmc_linux_device(d)}"
+
 mender_create_fw_env_config_file() {
     # Takes one argument, which is the file to put it in.
 
@@ -379,18 +396,10 @@ mender_create_fw_env_config_file() {
     # fw-utils seem to only be able to handle hex values.
     HEX_BOOTENV_SIZE="$(printf 0x%x "${BOOTENV_SIZE}")"
 
-    # Convert u-boot partition numbers to linux device references
-    # See [CONFIG_SYS_MMC_ENV_PART](https://github.com/u-boot/u-boot/blob/u-boot-2016.09.y/README#L4390) and
-    # [linux kernel mmc-dev-parts documentation](https://www.kernel.org/doc/Documentation/mmc/mmc-dev-parts.txt)
-    if [ ${MENDER_UBOOT_CONFIG_SYS_ENV_PART} = "1" ]; then
-        MENDER_UBOOT_ENV_PART_LINUX_APPEND="boot0"
-    elif [ ${MENDER_UBOOT_CONFIG_SYS_ENV_PART} = "2" ]; then
-        MENDER_UBOOT_ENV_PART_LINUX_APPEND="boot1"
-    fi
     # create fw_env.config file
     cat > $1 <<EOF
-${MENDER_STORAGE_DEVICE}${MENDER_UBOOT_ENV_PART_LINUX_APPEND} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1} $HEX_BOOTENV_SIZE
-${MENDER_STORAGE_DEVICE}${MENDER_UBOOT_ENV_PART_LINUX_APPEND} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2} $HEX_BOOTENV_SIZE
+/dev/${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1} $HEX_BOOTENV_SIZE
+/dev/${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2} $HEX_BOOTENV_SIZE
 EOF
 }
 

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -9,6 +9,9 @@ DEPLOYDIR = "${WORKDIR}/deploy-${PN}"
 
 MENDER_UBOOT_AUTO_CONFIGURE ??= "${@bb.utils.contains('DISTRO_FEATURES', 'mender-uboot', '1', '0', d)}"
 
+MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART ??= "0"
+MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK ??= "${MENDER_RESERVED_SPACE_BOOTLOADER_DATA}"
+
 ################################################################################
 # Patches.
 ################################################################################
@@ -42,12 +45,12 @@ do_provide_mender_defines() {
         bbfatal "To compile U-Boot with mender you have to add 'mender-uboot' to MENDER_FEATURES_ENABLE or DISTRO_FEATURES."
     fi
 
-    if [ $(expr ${MENDER_RESERVED_SPACE_BOOTLOADER_DATA} % \( ${MENDER_PARTITION_ALIGNMENT} \* 2 \)) -ne 0 ]; then
-        bbfatal "MENDER_RESERVED_SPACE_BOOTLOADER_DATA is not an even multiple of MENDER_PARTITION_ALIGNMENT."
+    if [ $(expr ${MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK} % \( ${MENDER_PARTITION_ALIGNMENT} \* 2 \)) -ne 0 ]; then
+        bbfatal "MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK is not an even multiple of MENDER_PARTITION_ALIGNMENT."
     fi
 
-    if [ ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE} -gt ${MENDER_RESERVED_SPACE_BOOTLOADER_DATA} ]; then
-        bbfatal "BOOTENV_SIZE (${BOOTENV_SIZE}) is too big to fit two copies inside MENDER_RESERVED_SPACE_BOOTLOADER_DATA (${MENDER_RESERVED_SPACE_BOOTLOADER_DATA}) with proper alignment. Please either: 1. Increase MENDER_RESERVED_SPACE_BOOTLOADER_DATA manually and make sure it is an *even* multiple of MENDER_PARTITION_ALIGNMENT (${MENDER_PARTITION_ALIGNMENT}). -or- 2. Decrease BOOTENV_SIZE in the U-Boot recipe so that it can fit two copies inside MENDER_RESERVED_SPACE_BOOTLOADER_DATA. Please see https://docs.mender.io/troubleshooting/yocto-project-build for more information."
+    if [ ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE} -gt ${MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK} ]; then
+        bbfatal "BOOTENV_SIZE (${BOOTENV_SIZE}) is too big to fit two copies inside MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK (${MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK}) with proper alignment. Please either: 1. Increase MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK manually and make sure it is an *even* multiple of MENDER_PARTITION_ALIGNMENT (${MENDER_PARTITION_ALIGNMENT}). -or- 2. Decrease BOOTENV_SIZE in the U-Boot recipe so that it can fit two copies inside MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK. Please see https://docs.mender.io/troubleshooting/yocto-project-build for more information."
     fi
 
     if [ -n "${MENDER_BOOT_PART}" ]; then
@@ -196,7 +199,7 @@ EOF
         cat >> ${S}/mender_Kconfig_fragment <<EOF
 CONFIG_ENV_OFFSET=$HEX_MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1
 CONFIG_ENV_OFFSET_REDUND=$HEX_MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2
-CONFIG_SYS_MMC_ENV_PART=0
+CONFIG_SYS_MMC_ENV_PART=${MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART}
 CONFIG_SYS_MMC_ENV_DEV=$MENDER_UBOOT_STORAGE_DEVICE
 EOF
     fi
@@ -376,10 +379,18 @@ mender_create_fw_env_config_file() {
     # fw-utils seem to only be able to handle hex values.
     HEX_BOOTENV_SIZE="$(printf 0x%x "${BOOTENV_SIZE}")"
 
+    # Convert u-boot partition numbers to linux device references
+    # See [CONFIG_SYS_MMC_ENV_PART](https://github.com/u-boot/u-boot/blob/u-boot-2016.09.y/README#L4390) and
+    # [linux kernel mmc-dev-parts documentation](https://www.kernel.org/doc/Documentation/mmc/mmc-dev-parts.txt)
+    if [ ${MENDER_UBOOT_CONFIG_SYS_ENV_PART} = "1" ]; then
+        MENDER_UBOOT_ENV_PART_LINUX_APPEND="boot0"
+    elif [ ${MENDER_UBOOT_CONFIG_SYS_ENV_PART} = "2" ]; then
+        MENDER_UBOOT_ENV_PART_LINUX_APPEND="boot1"
+    fi
     # create fw_env.config file
     cat > $1 <<EOF
-${MENDER_STORAGE_DEVICE} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1} $HEX_BOOTENV_SIZE
-${MENDER_STORAGE_DEVICE} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2} $HEX_BOOTENV_SIZE
+${MENDER_STORAGE_DEVICE}${MENDER_UBOOT_ENV_PART_LINUX_APPEND} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1} $HEX_BOOTENV_SIZE
+${MENDER_STORAGE_DEVICE}${MENDER_UBOOT_ENV_PART_LINUX_APPEND} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2} $HEX_BOOTENV_SIZE
 EOF
 }
 
@@ -399,10 +410,10 @@ mender_create_fw_env_config_file_mender-ubi() {
 EOF
 }
 
-# This should evaluate to the same as MENDER_RESERVED_SPACE_BOOTLOADER_DATA.
+# This should evaluate to the same as MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK.
 # The only reason it's not evaluated the same way is that we don't have the
 # necessary information (BOOTENV_SIZE) when evaluating
-# MENDER_RESERVED_SPACE_BOOTLOADER_DATA.
+# MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK.
 MENDER_BOOTENV_TOTAL_ALIGNED_SIZE = "${@mender_get_env_total_aligned_size(${BOOTENV_SIZE}, ${MENDER_PARTITION_ALIGNMENT})}"
 
 def mender_get_env_offset(start_offset, index, total_aligned_size):

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -21,6 +21,7 @@ SRC_URI_append_mender-uboot = " file://0001-Add-missing-header-which-fails-on-re
 SRC_URI_append_mender-uboot = " file://0002-Generic-boot-code-for-Mender.patch"
 SRC_URI_append_mender-uboot = " file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
 SRC_URI_append_mender-uboot = " file://0006-env-Kconfig-Add-descriptions-so-environment-options-.patch"
+SRC_URI_append_mender-uboot = " file://0007-Support-wrapper-scripts-for-fw_setenv.patch"
 
 SRC_URI_append_mender-uboot = "${@bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', \
                                                     '1', \


### PR DESCRIPTION
Allow mmcblk0boot0 or mmcblk0boot1 for uboot environment storage,
adding two variables:
1) MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART which sets the partition
used by u-boot for environment storage.  Also used to create the
appropriate suffix for the partition in the fw_env.conf file used by
u-boot fw utils.
2) MENDER_RESERVED_SPACE_BOOTLOADER_DATA_CHECK which overrides checks on
MENDER_RESERVED_SPACE_BOOTLOADER_DATA to allow you to set
MENDER_RESERVED_SPACE_BOOTLOADER_DATA to 0 (since this is used to
calculate user area offsets).

These changes will also require modifications to the mender client to
support the [read only](https://www.kernel.org/doc/Documentation/mmc/mmc-dev-parts.txt) access mechanism to the boot block.